### PR TITLE
Fixed spaces in executable path causing file not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ GM/obj
 GMLib/bin
 GMLib/obj
 rel/
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+GarbageMan/bin
+GarbageMan/obj
+GM/bin
+GM/obj
+GMLib/bin
+GMLib/obj
+rel/

--- a/GarbageMan/RunExecutable.xaml.cs
+++ b/GarbageMan/RunExecutable.xaml.cs
@@ -119,7 +119,7 @@ namespace GarbageMan
                 System.Windows.MessageBox.Show("Please pick proper filename", "RunExecutable", MessageBoxButton.OK, MessageBoxImage.Information);
             else
             {
-                string cmdLine = $"--path {path} --delay {delay} --dbpath {RealPath} --items {initialFlags} ";
+                string cmdLine = $"--path \"{path}\" --delay {delay} --dbpath {RealPath} --items {initialFlags} ";
                 if (args != "")
                     cmdLine += $"--arguments \"{args}\" ";
                 if (count > 1)


### PR DESCRIPTION
Simple quote addition to the --path cmdline argument passed to gm.exe, as any file w/ a space in it would break the argument.  Also added a .gitignore so when/if people compile w/ VS for debugging, it doesn't mess up the repo.