### PR TITLE
Fixed command-line parsing for arguments in GUI application, Added ability to specify execution working directory

### DIFF
--- a/GM/Program.cs
+++ b/GM/Program.cs
@@ -36,6 +36,9 @@ namespace GM
             [Option(SetName = "path", HelpText = "Program arguments.")]
             public string Arguments { get; set; }
 
+            [Option(SetName = "path", HelpText = "Set the working directory (Default: %SYSTEMROOT%\\system32)")]
+            public string WorkingDirectory { get; set; }
+
             [Option(SetName = "path", HelpText = "Wait before attaching (ms).")]
             public int Delay { get; set; }
 
@@ -207,6 +210,7 @@ namespace GM
                     path: opts.Path,
                     dataBasePath: opts.DBPath,
                     args: opts.Arguments,
+                    workingDirectory: opts.WorkingDirectory,
                     delay: opts.Delay,
                     dumpInterval: opts.Interval,
                     dumpCount: opts.Count,

--- a/GMLib/Collector.cs
+++ b/GMLib/Collector.cs
@@ -29,6 +29,7 @@ namespace GMLib
         public int Count { get; set; }
         public string Path { get; set; }
         public string Args { get; set; }
+        public string WorkingDirectory { get; set; }
         public int Delay { get; set; }
         public string CrashDump { get; set; }
         public int Pid { get; set; }
@@ -80,9 +81,11 @@ namespace GMLib
             DataBasePath = dataBasePath;
         }
 
+        // Added the option to set the working directory for the process
         public Collector(
             string path,
             string args,
+            string workingDirectory,
             int delay = 500,
             uint flags = Constants.COLLECT_EVERYTHING,
             uint initialFlags = Constants.COLLECT_EVERYTHING,
@@ -92,6 +95,7 @@ namespace GMLib
         {
             Path = path;
             Args = args;
+            WorkingDirectory = workingDirectory;
             Delay = delay;
             Interval = dumpInterval;
             Count = dumpCount;
@@ -158,6 +162,8 @@ namespace GMLib
                     proc.StartInfo.FileName = Path;
                     if (Args != null)
                         proc.StartInfo.Arguments = Args;
+                    if (WorkingDirectory != null)
+                        proc.StartInfo.WorkingDirectory = WorkingDirectory;
                     proc.StartInfo.CreateNoWindow = true;
                     proc.Start();
                     Pid = proc.Id;

--- a/GarbageMan/GarbageMan.csproj
+++ b/GarbageMan/GarbageMan.csproj
@@ -10,7 +10,7 @@
     <Description>.NET heap analyzer</Description>
     <Copyright />
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/GarbageMan/RunExecutable.xaml
+++ b/GarbageMan/RunExecutable.xaml
@@ -5,20 +5,22 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:GarbageMan"
         mc:Ignorable="d" Closing="RunExecutable_Closing"
-        Title="RunExecutable" Height="400" Width="400" Icon="assets/Recycle.ico">
+        Title="RunExecutable" Height="440" Width="400" Icon="assets/Recycle.ico">
     <Grid Background="#f8f8ff">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />            
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" MinHeight="38.62" />
+            <RowDefinition Height="Auto" MinHeight="39.96" />
+            <RowDefinition Height="38" />
+            <RowDefinition Height="37"/>
+            <RowDefinition Height="Auto" MinHeight="41" />
+            <RowDefinition Height="Auto" MinHeight="80.255" />
+            <RowDefinition Height="36" />
+            <RowDefinition Height="1"/>
+            <RowDefinition Height="Auto" MinHeight="46.96" />
+            <RowDefinition Height="Auto" MinHeight="74.76" />
         </Grid.RowDefinitions>
         <TextBlock Text="Run executable" Grid.Row="0" FontSize="14" FontWeight="SemiBold" Margin="5,10,0,10" />
-        <Grid Grid.Row="1" Margin="10">
+        <Grid Grid.Row="1" Margin="10,10,10,10">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
@@ -26,9 +28,9 @@
             </Grid.ColumnDefinitions>
             <TextBlock Text="Executable" Grid.Column="0" Margin="0,0,5,0" />
             <TextBox x:Name="RunExecutablePathTextBox" Grid.Column="1" Margin="0,0,5,0" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}"/>
-            <Button x:Name="RunExecutablePathPickerButton" Content="Pick file" Grid.Column="2" Click="RunExecutablePathPickerButton_Click" />            
+            <Button x:Name="RunExecutablePathPickerButton" Content="Pick file" Grid.Column="2" Click="RunExecutablePathPickerButton_Click" />
         </Grid>
-        <Grid Grid.Row="2" Margin="10">
+        <Grid Grid.Row="2" Margin="10,10,10,10" Grid.RowSpan="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
@@ -36,11 +38,19 @@
             <TextBlock Text="Arguments" Grid.Column="0" Margin="0,0,5,0" />
             <TextBox x:Name="RunExectableArgsTextBox" Grid.Column="1" Margin="0,0,5,0" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}"/>
         </Grid>
-        <Grid Grid.Row="3" Margin="10">
+        <Grid Grid.Row="3" Margin="10,10,10,10" Grid.RowSpan="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />                
-                <ColumnDefinition Width="Auto" />                
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="Working Directory (Optional)" Grid.Column="0" Margin="0,0,5,0" />
+            <TextBox x:Name="RunExectableWorkingDirTextBox" Grid.Column="1" Margin="0,0,5,0" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}"/>
+        </Grid>
+        <Grid Grid.Row="4" Margin="10,10,10,11">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
@@ -56,7 +66,7 @@
             <TextBox x:Name="RunExecutableSnapshotIntervalTextBox" Grid.Column="6" Width="50" Margin="0,0,2,0" />
             <TextBlock Text="ms" Grid.Column="7" />
         </Grid>
-        <Grid Grid.Row="4" Margin="10">
+        <Grid Grid.Row="5" Margin="10,9,10,10">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="1.7*" />
@@ -78,7 +88,7 @@
                 </StackPanel>
             </Grid>
         </Grid>
-        <Grid Grid.Row="5" Margin="10">
+        <Grid Grid.Row="6" Margin="10,10,10,5">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
@@ -88,7 +98,7 @@
             <TextBox x:Name="RunExecutableDatabaseNameTextBox" Grid.Column="1" Text="database.db" Margin="0,0,5,0" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}"/>
             <Button x:Name="RunExecutableDatabasePickerButton" Content="Pick file" Grid.Column="2" Click="RunExecutableDatabasePickerButton_Click" />
         </Grid>
-        <Grid Grid.Row="6" Margin="10">
+        <Grid Grid.Row="8" Margin="10,7,10,10">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
@@ -98,7 +108,7 @@
             <Button x:Name="RunExecutableStartButton" Content="Start" Grid.Column="1" Margin="5" Click="RunExecutableStartButton_Click"  />
             <Button x:Name="RunExecutableCancelButton" Content="Cancel" Grid.Column="2" Margin="5" Click="RunExecutableCancelButton_Click" />
         </Grid>
-        <StackPanel Grid.Row="7">
+        <StackPanel Grid.Row="9" Margin="0,0,0,38">
             <TextBlock x:Name="RunExecutableStatusText" Text="Creating database, please wait..." Margin="10,0,0,5" Visibility="Hidden" />
             <ProgressBar x:Name="RunExecutableProgressBar" IsIndeterminate="True" Height="5" Margin="20,0,20,10" Visibility="Hidden" />
         </StackPanel>

--- a/GarbageMan/RunExecutable.xaml.cs
+++ b/GarbageMan/RunExecutable.xaml.cs
@@ -121,7 +121,7 @@ namespace GarbageMan
             {
                 string cmdLine = $"--path \"{path}\" --delay {delay} --dbpath {RealPath} --items {initialFlags} ";
                 if (args != "")
-                    cmdLine += $"--arguments \"{args}\" ";
+                    cmdLine += $"--arguments=\"{args}\" ";
                 if (count > 1)
                     cmdLine += $"--count {count} --interval {interval} --nextitems {nextFlags}";
 

--- a/GarbageMan/RunExecutable.xaml.cs
+++ b/GarbageMan/RunExecutable.xaml.cs
@@ -94,6 +94,7 @@ namespace GarbageMan
             // Get all the settings
             string path = RunExecutablePathTextBox.Text;
             string args = RunExectableArgsTextBox.Text;
+            string workingDirectory = RunExectableWorkingDirTextBox.Text;
             int delay = int.Parse((RunExecutableDelayTextBox.Text == "") ? "" : RunExecutableDelayTextBox.Text);
             int count = int.Parse((RunExecutableSnapshotCountTextBox.Text == "") ? "1" : RunExecutableSnapshotCountTextBox.Text);
             int interval = int.Parse((RunExecutableSnapshotIntervalTextBox.Text == "") ? "0" : RunExecutableSnapshotIntervalTextBox.Text);
@@ -122,6 +123,8 @@ namespace GarbageMan
                 string cmdLine = $"--path \"{path}\" --delay {delay} --dbpath {RealPath} --items {initialFlags} ";
                 if (args != "")
                     cmdLine += $"--arguments=\"{args}\" ";
+                if (workingDirectory != "")
+                    cmdLine += $"--workingdirectory=\"{workingDirectory}\" ";
                 if (count > 1)
                     cmdLine += $"--count {count} --interval {interval} --nextitems {nextFlags}";
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Crash course:
 
 If you need to use `psnotify` for dumping, you need to extract it to `C:\psnotify` (yes, that's fixed for now). Just run `psnotify.exe` and stop it with `Ctrl+C` when done. It will create minidumps in `C:\dumps`. You can later then analyze those dumps with GarbageMan.
 
+**Note**: If you'd like to specify a working directory for the program to execute from, make sure psnotify isn't running as it will conflict with GarbageMan.
+
 
 ## How to compile the GUI tool
 


### PR DESCRIPTION
This is a really simple fix, but I ran into an issue that caused the GM utility to crash when trying to use it to execute programs from within the GUI when the program arguments start with a dash ("-"). It is because of an outstanding issue attached to the CommandLine dependency. [#690](https://github.com/commandlineparser/commandline/pull/690)

It doesn't seem like this is going to be merged over there any time soon, so the work-around is to use the equals ("=") operator so the dependency can parse it properly.